### PR TITLE
Untitled

### DIFF
--- a/core/components/gallery/elements/snippets/snippet.gallery.php
+++ b/core/components/gallery/elements/snippets/snippet.gallery.php
@@ -102,7 +102,11 @@ if (!$showInactive) {
     ));
 }
 
-$c->sortby($sortAlias.'.'.$sort,$dir);
+if (strcasecmp($sort,'rand')==0) {
+    $c->sortby('RAND()',$dir);
+} else {
+    $c->sortby($sortAlias.'.'.$sort,$dir);
+}
 if (!empty($limit)) $c->limit($limit,$start);
 $items = $modx->getCollection('galItem',$c);
 


### PR DESCRIPTION
Added option to gallery snippet to return images sorted randomly.

To sort images randomly add:

```
&sort=`RAND` 
```

To return a single random image combine with: 

```
&limit=`1`
```

.
