### PR TITLE
Added random sorting for albums

### DIFF
--- a/core/components/gallery/elements/snippets/snippet.galleryalbums.php
+++ b/core/components/gallery/elements/snippets/snippet.galleryalbums.php
@@ -44,6 +44,12 @@ $albumCoverSort = $modx->getOption('albumCoverSort',$scriptProperties,'rank');
 $albumCoverSortDir = $modx->getOption('albumCoverSortDir',$scriptProperties,'ASC');
 $showName = $modx->getOption('showName',$scriptProperties,true);
 
+/* add random sorting for albums */
+if (in_array(strtolower($sort),array('random','rand()','rand'))) {
+    $sort = 'RAND()';
+    $dir = '';
+}
+
 /* handle sorting for album cover */
 if ($albumCoverSort == 'rank') {
     $albumCoverSort = 'AlbumItems.rank';


### PR DESCRIPTION
Similar to the random sorting for album-cover, I added random sorting for album-list.
Example usage: A sidebar-widget show 3 of x random albums. Randomize on each page reload.
