### PR TITLE
Feature: TinyMCE Integration

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -35,7 +35,7 @@ set_time_limit(0);
 define('PKG_NAME','Gallery');
 define('PKG_NAME_LOWER','gallery');
 define('PKG_VERSION','1.2.2');
-define('PKG_RELEASE','pl');
+define('PKG_RELEASE','pl4');
 
 /* define sources */
 $root = dirname(dirname(__FILE__)).'/';

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -35,7 +35,7 @@ set_time_limit(0);
 define('PKG_NAME','Gallery');
 define('PKG_NAME_LOWER','gallery');
 define('PKG_VERSION','1.2.2');
-define('PKG_RELEASE','pl4');
+define('PKG_RELEASE','pl');
 
 /* define sources */
 $root = dirname(dirname(__FILE__)).'/';

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -101,4 +101,113 @@ $settings['gallery.']->fromArray(array(
 ),'',true,true);
 */
 
+/* Settings for the TinyMCE integration */
+$settings['gallery.use_richtext']= $modx->newObject('modSystemSetting');
+$settings['gallery.use_richtext']->fromArray(array(
+    'key' => 'gallery.use_richtext',
+    'value' => false,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.width']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.width']->fromArray(array(
+    'key' => 'gallery.tiny.width',
+    'value' => '95%',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.height']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.height']->fromArray(array(
+    'key' => 'gallery.tiny.height',
+    'value' => 200,
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.buttons1']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.buttons1']->fromArray(array(
+    'key' => 'gallery.tiny.buttons1',
+    'value' => 'undo,redo,selectall,pastetext,pasteword,charmap,separator,image,modxlink,unlink,media,separator,code,help',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.buttons2']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.buttons2']->fromArray(array(
+    'key' => 'gallery.tiny.buttons2',
+    'value' => 'bold,italic,underline,strikethrough,sub,sup,separator,bullist,numlist,outdent,indent,separator,justifyleft,justifycenter,justifyright,justifyfull',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.buttons3']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.buttons3']->fromArray(array(
+    'key' => 'gallery.tiny.buttons3',
+    'value' => 'styleselect,formatselect,separator,styleprops',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.buttons4']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.buttons4']->fromArray(array(
+    'key' => 'gallery.tiny.buttons4',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.buttons5']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.buttons5']->fromArray(array(
+    'key' => 'gallery.tiny.buttons5',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.custom_plugins']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.custom_plugins']->fromArray(array(
+    'key' => 'gallery.tiny.custom_plugins',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.theme']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.theme']->fromArray(array(
+    'key' => 'gallery.tiny.theme',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.theme_advanced_blockformats']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.theme_advanced_blockformats']->fromArray(array(
+    'key' => 'gallery.tiny.theme_advanced_blockformats',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
+$settings['gallery.tiny.theme_advanced_css_selectors']= $modx->newObject('modSystemSetting');
+$settings['gallery.tiny.theme_advanced_css_selectors']->fromArray(array(
+    'key' => 'gallery.tiny.theme_advanced_selectors',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'gallery',
+    'area' => 'TinyMCE',
+),'',true,true);
+
 return $settings;

--- a/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
@@ -277,7 +277,7 @@ GAL.window.UpdateItem = function(config) {
         title: _('gallery.item_update')
         ,id: this.ident
         ,height: 150
-        ,width: 475
+        ,width: '55%'
         ,url: GAL.config.connector_url
         ,action: 'mgr/item/update'
         ,fileUpload: true
@@ -297,7 +297,7 @@ GAL.window.UpdateItem = function(config) {
             ,fieldLabel: _('description')
             ,name: 'description'
             ,id: 'gal-'+this.ident+'-description'
-            ,width: 300
+            ,width: '85%'
         },{
             xtype: 'checkbox'
             ,fieldLabel: _('gallery.active')
@@ -323,6 +323,9 @@ GAL.window.UpdateItem = function(config) {
         }]
     });
     GAL.window.UpdateItem.superclass.constructor.call(this,config);
+    this.on('activate',function() {
+        if (typeof Tiny != 'undefined') { MODx.loadRTE('gal-' + this.ident + '-description'); }
+    });
 };
 Ext.extend(GAL.window.UpdateItem,MODx.Window);
 Ext.reg('gal-window-item-update',GAL.window.UpdateItem);

--- a/assets/components/gallery/js/mgr/widgets/album/album.panel.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.panel.js
@@ -276,7 +276,7 @@ GAL.window.UploadItem = function(config) {
         title: _('gallery.item_upload')
         ,id: this.ident
         ,height: 150
-        ,width: 475
+        ,width: '55%'
         ,url: GAL.config.connector_url
         ,action: 'mgr/item/upload'
         ,fileUpload: true
@@ -300,7 +300,7 @@ GAL.window.UploadItem = function(config) {
             ,fieldLabel: _('description')
             ,name: 'description'
             ,id: 'gal-'+this.ident+'-description'
-            ,width: 300
+            ,width: '85%'
         },{
             xtype: 'checkbox'
             ,fieldLabel: _('gallery.active')
@@ -325,6 +325,9 @@ GAL.window.UploadItem = function(config) {
         }]
     });
     GAL.window.UploadItem.superclass.constructor.call(this,config);
+    this.on('activate',function() {
+        if (typeof Tiny != 'undefined') { MODx.loadRTE('gal-' + this.ident + '-description'); }
+    });
 };
 Ext.extend(GAL.window.UploadItem,MODx.Window);
 Ext.reg('gal-window-item-upload',GAL.window.UploadItem);

--- a/core/components/gallery/controllers/mgr/album/update.php
+++ b/core/components/gallery/controllers/mgr/album/update.php
@@ -30,6 +30,47 @@ $modx->regClientStartupScript($gallery->config['jsUrl'].'mgr/utils/ddview.js');
 $modx->regClientStartupScript($gallery->config['jsUrl'].'mgr/widgets/album/album.items.view.js');
 $modx->regClientStartupScript($gallery->config['jsUrl'].'mgr/widgets/album/album.panel.js');
 $modx->regClientStartupScript($gallery->config['jsUrl'].'mgr/sections/album/update.js');
+
+/* If we want to use Tiny, we'll need some extra files. */
+$useTiny = $modx->getOption('gallery.use_richtext',$gallery->config,false);
+if ($useTiny) {
+    $tinyCorePath = $modx->getOption('tiny.core_path',null,$modx->getOption('core_path').'components/tinymce/');
+    if (file_exists($tinyCorePath.'tinymce.class.php')) {
+
+        /* First fetch the gallery+tiny specific settings */
+        $cb1 =  $modx->getOption('gallery.tiny.buttons1');
+        $cb2 =  $modx->getOption('gallery.tiny.buttons2');
+        $cb3 =  $modx->getOption('gallery.tiny.buttons3');
+        $cb4 =  $modx->getOption('gallery.tiny.buttons4');
+        $cb5 =  $modx->getOption('gallery.tiny.buttons5');
+        $plugins =  $modx->getOption('gallery.tiny.custom_plugins');
+        $theme =  $modx->getOption('gallery.tiny.theme');
+        $bfs =  $modx->getOption('gallery.tiny.theme_advanced_blockformats');
+        $css =  $modx->getOption('gallery.tiny.theme_advanced_css_selectors');
+
+        /* If the settings are empty, override them with the generic tinymce settings. */
+        $tinyProperties = array(
+            'height' => $modx->getOption('gallery.tiny.height',null,200),
+            'width' => $modx->getOption('gallery.tiny.width',null,400),
+            'tiny.custom_buttons1' => (!empty($cb1)) ? $cb1 : $modx->getOption('tiny.custom_buttons1'),
+            'tiny.custom_buttons2' => (!empty($cb2)) ? $cb2 : $modx->getOption('tiny.custom_buttons2'),
+            'tiny.custom_buttons3' => (!empty($cb3)) ? $cb3 : $modx->getOption('tiny.custom_buttons3'),
+            'tiny.custom_buttons4' => (!empty($cb4)) ? $cb4 : $modx->getOption('tiny.custom_buttons4'),
+            'tiny.custom_buttons5' => (!empty($cb5)) ? $cb5 : $modx->getOption('tiny.custom_buttons5'),
+            'tiny.custom_plugins' => (!empty($plugins)) ? $plugins : $modx->getOption('tiny.custom_plugins'),
+            'tiny.editor_theme' => (!empty($theme)) ? $theme : $modx->getOption('tiny.editor_theme'),
+            'tiny.theme_advanced_blockformats' => (!empty($bfs)) ? $bfs : $modx->getOption('tiny.theme_advanced_blockformats'),
+            'tiny.css_selectors' => (!empty($css)) ? $css : $modx->getOption('tiny.css_selectors'),
+        );
+        
+        require_once $tinyCorePath.'tinymce.class.php';
+        $tiny = new TinyMCE($modx,$tinyProperties);
+        $tiny->setProperties($tinyProperties);
+        $html = $tiny->initialize();
+        $modx->regClientHTMLBlock($html);
+    }
+}
+
 $output = '<div id="gal-panel-album-div"></div>';
 
 return $output;


### PR DESCRIPTION
New Feature: integrating TinyMCE as rich text solution for item description fields.
Comes with system settings to configure the most important aspects of the RTE (custom buttons, plugins, theme, size) and a switch to turn it on/off which defaults to off. (perhaps enable by default? Not sure on the implications of such an "in your face" release of a new feature, especially when you don't use the description field for lengthy text.

(cherry picked from commit b680158)
