### PR TITLE
[#116] Add &gallerifficCss parameter defining a specific css file to use 

### DIFF
--- a/core/components/gallery/docs/changelog.txt
+++ b/core/components/gallery/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for Gallery.
 
+bitbox fork 0.1.0
+====================================
+- [#116] Add &gallerifficCss parameter defining a specific css file to use for Galleriffic plugin
+
 Gallery 1.3.0
 ====================================
 - [#137] Add multi-upload to Gallery albums

--- a/core/components/gallery/model/gallery/plugins/galleriffic.class.php
+++ b/core/components/gallery/model/gallery/plugins/galleriffic.class.php
@@ -88,7 +88,7 @@ class Galleriffic extends GalleryPlugin {
     protected function renderCssJs() {
         $useCss = $this->modx->getOption('gallerifficUseCss',$this->config,true);
         if ($useCss) {
-            $this->modx->regClientCSS($this->gallery->config['assetsUrl'].'packages/galleriffic20/css/galleriffic-2.css');
+            $this->modx->regClientCSS($this->gallery->config['assetsUrl'].'packages/galleriffic20/css/'.$this->modx->getOption('gallerifficCss',$this->config,'galleriffic-2.css'));
         }
         $this->modx->regClientStartupScript($this->gallery->config['assetsUrl'].'packages/galleriffic20/js/jquery.galleriffic.js');
         $this->modx->regClientStartupScript($this->gallery->config['assetsUrl'].'packages/galleriffic20/js/jquery.opacityrollover.js');


### PR DESCRIPTION
[#116] Add &gallerifficCss parameter defining a specific css file to use for Galleriffic plugin

Allow to use &galleryfficCss parameter like:
[[!Gallery?
&album=My Album
&plugin=galleriffic
&gallerifficCss=my_gallerific.css]]

And let users have different Gallerific layouts in a website
