### PR TITLE
change gal-panel-album-items height into minHeight.

### DIFF
--- a/assets/components/gallery/js/mgr/widgets/album/album.panel.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.panel.js
@@ -184,7 +184,7 @@ GAL.panel.AlbumItems = function(config) {
             ,cls: 'browser-view'
             ,region: 'center'
             ,width: '75%'
-            ,height: 450
+            ,minHeight: 450
             ,autoScroll: true
             ,border: false
             ,items: [{


### PR DESCRIPTION
change gal-panel-album-items height into minHeight. 

drag&drop with scrolling doesnt work, this way all gallery images (items) from one page are all visable on the page so that there is no scrollbar
