### PR TITLE
Added to renderCssJs method. This now allows for the passing in of a new...

### DIFF
--- a/core/components/gallery/model/gallery/plugins/galleriffic.class.php
+++ b/core/components/gallery/model/gallery/plugins/galleriffic.class.php
@@ -90,8 +90,21 @@ class Galleriffic extends GalleryPlugin {
         if ($useCss) {
             $this->modx->regClientCSS($this->modx->getOption('gallerifficCss',$this->config,$this->gallery->config['assetsUrl'].'packages/galleriffic20/css/galleriffic-2.css'));
         }
-        $this->modx->regClientStartupScript($this->gallery->config['assetsUrl'].'packages/galleriffic20/js/jquery.galleriffic.js');
-        $this->modx->regClientStartupScript($this->gallery->config['assetsUrl'].'packages/galleriffic20/js/jquery.opacityrollover.js');
+
+        $renderJsOnStartup = (boolean) $this->modx->getOption('gallerifficRenderJsOnStartup',$this->config,true);
+
+
+        if($renderJsOnStartup){
+            $regJsOn   = 'regClientStartupScript';
+            $regHTMLOn = 'regClientStartupHTMLBlock';
+        }
+        else{
+            $regJsOn   = 'regClientScript';
+            $regHTMLOn = 'regClientHTMLBlock';
+        }
+
+        $this->modx->$regJsOn($this->gallery->config['assetsUrl'].'packages/galleriffic20/js/jquery.galleriffic.js');
+        $this->modx->$regJsOn($this->gallery->config['assetsUrl'].'packages/galleriffic20/js/jquery.opacityrollover.js');
 
 
         $jsTpl = $this->modx->getOption('gallerifficJsTpl',$this->config,'GallerifficJS');
@@ -99,6 +112,6 @@ class Galleriffic extends GalleryPlugin {
             'options' => $this->modx->toJSON($this->config),
         );
         $output = $this->gallery->getChunk($jsTpl,$properties);
-        $this->modx->regClientStartupHTMLBlock($output);
+        $this->modx->$regHTMLOn($output);
     }
 }


### PR DESCRIPTION
... param from the tag called "gallerifficRenderJsOnStartup".

If not set all works as it did when rendering Js to screen using regClientStartupScript and regClientStartupHTMLScript. If set to zero (&gallerifficRenderJsOnStartup=`0`) then Js is rendered using regClientScript and regHTMLBlock.

This allows for users whos site run all js at the end of the page to move the default position of the js to before </body> rather then before </head>
