### PR TITLE
Fixes album item de-activation issue.

### DIFF
--- a/core/components/gallery/processors/mgr/item/update.class.php
+++ b/core/components/gallery/processors/mgr/item/update.class.php
@@ -33,7 +33,7 @@ class GalleryItemUpdateProcessor extends modObjectUpdateProcessor {
     public $languageTopics = array('gallery:default');
 
     public function beforeSet() {
-        $this->setCheckbox('active');
+        $this->setCheckbox('active',true);
         return parent::beforeSet();
     }
 


### PR DESCRIPTION
The docs for `setCheckbox( string $k, boolean $force = false )` ...

> Special helper method for handling checkboxes. Only set value if passed or $force is true, and check for a not empty value or string 'false'.

Since Extjs does not send 0 for the unchecked active field, the album item never gets set to 0 (inactive). We have to force the setting of `active` even when it's not present.

Cheers!
-mgb
