### PR TITLE
Add itemsPerPage field in album manager page

### DIFF
--- a/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
@@ -39,7 +39,7 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
             }
             ,listeners: {
                 'success':{fn:function(r) {
-                    this.run();
+                    this.store.reload();
                 },scope:this}
             }
         });
@@ -69,7 +69,7 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
         this.windows.updateItem = MODx.load({
             xtype: 'gal-window-item-update'
             ,listeners: {
-                'success': {fn:function() { this.run(); },scope:this}
+                'success': {fn:function() { this.store.reload(); },scope:this}
             }
         });
         this.windows.updateItem.setValues(data);
@@ -89,7 +89,7 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
                 ,id: data.id
             }
             ,listeners: {
-                'success': {fn:function(r) { this.run(); },scope:this}
+                'success': {fn:function(r) { this.pagingBar.changePage(1); this.store.reload(); },scope:this}
             }
         });
     }
@@ -111,7 +111,7 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
                 ,ids: ids.substr(1)
             }
             ,listeners: {
-                'success': {fn:function(r) { this.run(); },scope:this}
+                'success': {fn:function(r) { this.pagingBar.changePage(1); this.store.reload(); },scope:this}
             }
         });
         return true;
@@ -121,7 +121,6 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
         p = p || {};
         var v = {};
         Ext.apply(v,this.store.baseParams);
-        Ext.apply(v,{limit: this.pagingBar.pageSize});
         Ext.apply(v,p);
         this.pagingBar.changePage(1);
         this.store.baseParams = v;
@@ -131,14 +130,14 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
     ,sortBy: function(sel) {
         var v = sel.getValue();
         this.store.baseParams.sorter = v;
-        this.run();
+        this.store.reload();
         return true;
     }
     
     ,sortDir: function(sel) {
         var v = sel.getValue();
         this.store.baseParams.dir = v;
-        this.run();
+        this.store.reload();
     }
     
     ,showDetails : function(){
@@ -268,5 +267,3 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
     }
 });
 Ext.reg('gal-view-album-items',GAL.view.AlbumItems);
-
-

--- a/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
@@ -121,6 +121,7 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
         p = p || {};
         var v = {};
         Ext.apply(v,this.store.baseParams);
+        Ext.apply(v,{limit: this.pagingBar.pageSize});
         Ext.apply(v,p);
         this.pagingBar.changePage(1);
         this.store.baseParams = v;

--- a/assets/components/gallery/js/mgr/widgets/album/album.panel.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.panel.js
@@ -155,10 +155,41 @@ GAL.panel.AlbumItems = function(config) {
         ,style: 'overflow: auto;'
     });
     this.view.pagingBar = new Ext.PagingToolbar({
-        pageSize: 24
+        pageSize: config.pageSize || (parseInt(MODx.config.default_per_page) || 20)
         ,store: this.view.store
         ,displayInfo: true
         ,autoLoad: true
+        ,items: [
+            '-'
+        	,_('per_page')+':'
+        	,{
+		        xtype: 'textfield'
+		        ,value: config.pageSize || (parseInt(MODx.config.default_per_page) || 20)
+		        ,width: 40
+		        ,listeners: {
+		            'change': {fn:function(tf,nv,ov) {
+		                if (Ext.isEmpty(nv)) return false;
+		                nv = parseInt(nv);
+		                this.view.pagingBar.pageSize = nv;
+		                this.view.store.load({params:{
+		                    start:0
+		                    ,limit: nv
+		                }});
+		            },scope:this}
+		            ,'render': {fn: function(cmp) {
+		                new Ext.KeyMap(cmp.getEl(), {
+		                    key: Ext.EventObject.ENTER
+		                    ,fn: function() {
+		                        this.fireEvent('change',this.getValue());
+		                        this.blur();
+		                        return true;}
+		                    ,scope: cmp
+		                });
+		            },scope:this}
+		        }
+	    	}
+	    	,'-'
+	    ]
     });
     var dv = this.view;
     


### PR DESCRIPTION
I have faced with such problem: I had to sort items, there is no problem to sort items within one page, but I did not find the way to do it between two pages, so I have added field "Items per page" to bottom paging bar, like one under MODx system settings grid (for example).

Additionally, default value for this field is taking from default_per_page system setting
