### PR TITLE
added placeholder for the galItem url field for use in thumbTpl

### DIFF
--- a/core/components/gallery/elements/snippets/snippet.gallery.php
+++ b/core/components/gallery/elements/snippets/snippet.gallery.php
@@ -184,6 +184,7 @@ foreach ($items as $item) {
     if (!empty($album)) $itemArray['album'] = $album->get('id');
     if (!empty($tag)) $itemArray['tag'] = $tag;
     $itemArray['linkToImage'] = $linkToImage;
+    $itemArray['url'] = $item->get('url');
     $itemArray['imageGetParam'] = $imageGetParam;
     $itemArray['albumRequestVar'] = $albumRequestVar;
     $itemArray['tagRequestVar'] = $tagRequestVar;


### PR DESCRIPTION
I found it useful to have the galItem url field contents available as a placeholder in thumbTpl.  It seems only logical, since most of the fields are in use there already.  Thanks for considering this simple addition.
