### PR TITLE
Depth

### DIFF
--- a/core/components/gallery/model/gallery/galalbum.class.php
+++ b/core/components/gallery/model/gallery/galalbum.class.php
@@ -343,25 +343,25 @@ class galAlbum extends xPDOSimpleObject {
      * @return array           An array of IDs of children of this album (if found any, otherwise false).
      */
     public function getChildIds ($depth) {
+        // Depth may have reached zero in recursion
+        if (empty($depth)) return false;
+
         $childIds = array();
-        
-        if ($depth) {
-            $children = $this->getMany('Children');
-            if (count($children)) {
-                foreach ((array) $children as $child) {
-                    $childIds[] = $child->get('id');
-                }
-                if ($depth > 1 || $depth < 0) {
-                    foreach ($children as $child) {
-                        $childChildrenIds = $child->getChildIds($depth - 1);
-                        if ($childChildrenIds)
-                            $childIds = array_merge($childIds, $childChildrenIds);
-                    }
-                }
-                return $childIds;
+        $children = $this->getMany('Children');
+        if (count($children)) {
+            foreach ((array) $children as $child) {
+                $childIds[] = $child->get('id');
             }
-            /* If no children found */
-            return false;
+            if ($depth > 1 || $depth < 0) {
+                foreach ($children as $child) {
+                    $childChildrenIds = $child->getChildIds($depth - 1);
+                    if ($childChildrenIds)
+                        $childIds = array_merge($childIds, $childChildrenIds);
+                }
+            }
+            return $childIds;
         }
+        /* If no children found */
+        return false;
     }
 }

--- a/core/components/gallery/model/gallery/galalbum.class.php
+++ b/core/components/gallery/model/gallery/galalbum.class.php
@@ -335,4 +335,33 @@ class galAlbum extends xPDOSimpleObject {
         }
         return $albums;
     }
+
+    /**
+     * Return array with ids of children albums up to given depth
+     * 
+     * @param int    $depth    How many sublevels of albums to get. Set to -1 to grab all the sublevels.
+     * @return array           An array of IDs of children of this album (if found any, otherwise false).
+     */
+    public function getChildIds ($depth) {
+        $childIds = array();
+        
+        if ($depth) {
+            $children = $this->getMany('Children');
+            if (count($children)) {
+                foreach ((array) $children as $child) {
+                    $childIds[] = $child->get('id');
+                }
+                if ($depth > 1 || $depth < 0) {
+                    foreach ($children as $child) {
+                        $childChildrenIds = $child->getChildIds($depth - 1);
+                        if ($childChildrenIds)
+                            $childIds = array_merge($childIds, $childChildrenIds);
+                    }
+                }
+                return $childIds;
+            }
+            /* If no children found */
+            return false;
+        }
+    }
 }

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -262,6 +262,7 @@ class galItem extends xPDOSimpleObject {
 
             $album = $modx->getOption('album',$scriptProperties,false);
             $depth = $modx->getOption('depth',$scriptProperties,false);
+            $groupByAlbum = $modx->getOption('groupByAlbum',$scriptProperties,true); // Only if using &depth
             $tag = $modx->getOption('tag',$scriptProperties,'');
             $limit = $modx->getOption('limit',$scriptProperties,0);
             $start = $modx->getOption('start',$scriptProperties,0);
@@ -334,6 +335,10 @@ class galItem extends xPDOSimpleObject {
             $c->select(array(
                 '('.$tagSql.') AS tags',
             ));
+            /* If &depth option is in use, group by albums first */
+            if ($depth && $groupByAlbum) {
+                $c->sortby('Album.rank', 'ASC');
+            }
             if (in_array(strtolower($sort),array('random','rand()','rand'))) {
                 $c->sortby('RAND()',$dir);
             } else {

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -261,6 +261,7 @@ class galItem extends xPDOSimpleObject {
         } else {
 
             $album = $modx->getOption('album',$scriptProperties,false);
+            $depth = $modx->getOption('depth',$scriptProperties,false);
             $tag = $modx->getOption('tag',$scriptProperties,'');
             $limit = $modx->getOption('limit',$scriptProperties,0);
             $start = $modx->getOption('start',$scriptProperties,0);
@@ -297,6 +298,12 @@ class galItem extends xPDOSimpleObject {
                 $c->where(array(
                     'Album.'.$albumField => $album->get($albumField),
                 ));
+                /* Also display some sublevels of albums if asked for */
+                if ($depth) {
+                    $childAlbums = $album->getChildIds($depth);
+                    if ($childAlbums)
+                        $c->orCondition(array('Album.id:IN' => $childAlbums));
+                }
                 $activeAlbum['id'] = $album->get('id');
                 $activeAlbum['name'] = $album->get('name');
                 $activeAlbum['description'] = $album->get('description');


### PR DESCRIPTION
Support for a &depth parameter on the Gallery snippet. Specifies how many sublevels deep to go when getting galItems. 0 to disable, -1 to grab all the sublevels.
