### PR TITLE
[#218] Fix property itemCls from being assigned activeCls's value

### DIFF
--- a/_build/properties/properties.gallery.php
+++ b/_build/properties/properties.gallery.php
@@ -83,7 +83,7 @@ $properties = array(
         'lexicon' => 'gallery:properties',
     ),
     array(
-        'name' => 'itemCls',
+        'name' => 'activeCls',
         'desc' => 'gallery.activecls_desc',
         'type' => 'textfield',
         'options' => '',


### PR DESCRIPTION
There was a typo in properties.gallery.php which assigned the `&itemCls` parameter a value which was supposed to be for `&activeCls`.
