### PR TITLE
Added ability to show all childs and subchilds of selected parent album by new TV option.

### DIFF
--- a/core/components/gallery/elements/tv/galleryalbumlist.inputproperties.tpl
+++ b/core/components/gallery/elements/tv/galleryalbumlist.inputproperties.tpl
@@ -105,6 +105,15 @@ MODx.load({
         ,width: 300
         ,listeners: oc
     },{
+        xtype: 'combo-boolean'
+        ,fieldLabel: '{/literal}{$gl.subchilds}{literal}'
+        ,description: '{/literal}{$gl.subchilds_desc}{literal}'
+        ,name: 'inopt_subchilds'
+        ,id: 'inopt_subchilds{/literal}{$tv}{literal}'
+        ,value: params['subchilds'] || ''
+        ,width: 300
+        ,listeners: oc
+    },{
         xtype: 'textfield'
         ,fieldLabel: '{/literal}{$gl.width}{literal}'
         ,description: '{/literal}{$gl.width_desc}{literal}'

--- a/core/components/gallery/elements/tv/input/galleryalbumlist.php
+++ b/core/components/gallery/elements/tv/input/galleryalbumlist.php
@@ -41,6 +41,7 @@ $start = (int)$modx->getOption('start',$params,0);
 $showNone = (boolean)$modx->getOption('showNone',$params,true);
 $showCover = (boolean)$modx->getOption('showCover',$params,true);
 $parent = $modx->getOption('parent',$params,'');
+$subchilds = $modx->getOption('subchilds',$params,false);
 
 /* get albums */
 $c = $modx->newQuery('galAlbum');
@@ -57,6 +58,17 @@ if ($limit > 0) {
     $c->limit($limit,$start);
 }
 $albums = $modx->getCollection('galAlbum',$c);
+
+if(($parent != '') && ($subchilds == true)){
+        $album = $modx->getObject('galAlbum',(int)$parent);
+        if($album != null){
+            $albumsWithSubs = array();
+            $gallery = new Gallery($modx);
+            $gallery->getAllChilds($album, $albumsWithSubs, $sort, $dir, -1);
+            
+            $albums = $albumsWithSubs;
+        }
+}
 
 /* setup thumb properties */
 $thumbProperties = array(

--- a/core/components/gallery/lexicon/cs/tvprops.inc.php
+++ b/core/components/gallery/lexicon/cs/tvprops.inc.php
@@ -99,3 +99,9 @@ $_lang['galtv.width'] = 'Šířka';
 
 // $_lang['galtv.width_desc'] = 'The width of the combobox, in pixels.';
 $_lang['galtv.width_desc'] = 'Šířka rozbalovací nabídky v px.';
+
+//$_lang['galtv.subchilds'] = 'Show all of parent sub childs';
+$_lang['galtv.subchilds'] = 'Zobrazit všechny potomky';
+
+//$_lang['galtv.subchilds_desc'] = 'Show all of parent childs and subchilds.';
+$_lang['galtv.subchilds_desc'] = 'Zobrazit všechny potomky od zadaného rodiče.';

--- a/core/components/gallery/lexicon/en/tvprops.inc.php
+++ b/core/components/gallery/lexicon/en/tvprops.inc.php
@@ -49,3 +49,5 @@ $_lang['galtv.start'] = 'Start Index';
 $_lang['galtv.start_desc'] = 'If limit is greater than 0, will start at this index.';
 $_lang['galtv.width'] = 'Width';
 $_lang['galtv.width_desc'] = 'The width of the combobox, in pixels.';
+$_lang['galtv.subchilds'] = 'Show all of parent sub childs';
+$_lang['galtv.subchilds_desc'] = 'Show all of parent childs and subchilds.';

--- a/core/components/gallery/model/gallery/gallery.class.php
+++ b/core/components/gallery/model/gallery/gallery.class.php
@@ -355,4 +355,31 @@ class Gallery {
         $this->debugTimer = false;
         return $totalTime;
     }
+    
+    /**
+     * Recursion
+     * Return all childs and subchilds for selected album
+     *
+     * @access public
+     * @param GalAlbumItem $album Album for which is selecting childs
+     * @param array $albumsWithSubs Array with results
+     * @param string $sort Element to sort by
+     * @param string $dir Sort direction
+     * @param int $deep Depth of actual album
+     */
+    public function getAllChilds($album, &$albumsWithSubs, $sort, $dir, $deep){
+        $c = $this->modx->newQuery('galAlbum');
+        $c->where(array(
+            'parent' => $album->get('id'),
+            'active' => 1,
+        ));
+        $c->sortby($sort,$dir);
+        $album->set('name', str_repeat('&nbsp;&nbsp;', ($deep == -1)? 0 : $deep).$album->get('name'));
+        $subAlbums = $this->modx->getCollection('galAlbum',$c);
+        
+        foreach($subAlbums as $subAlbum){
+            $albumsWithSubs[] = $subAlbum;
+            $this->getAllChilds($subAlbum, $albumsWithSubs, $sort, $dir, $deep+1);
+        }
+    }
 }


### PR DESCRIPTION
I added new option for TV galleryalbumlist that allows you to select all subchilds and childs of parent album.

In album structure:
1
1.1
1.1.1
1.1.2
1.2
2

When you set parent album to 1 with my new option turned off you get albums 1.1 and 1.2 with my option set to on you get 1.1, 1.1.1, 1.1.2 and 1.2
