### PR TITLE
Applied GROUP BY galItem.id to prevent duplication during LEFT JOIN modx...

### DIFF
--- a/core/components/gallery/processors/mgr/item/getlist.class.php
+++ b/core/components/gallery/processors/mgr/item/getlist.class.php
@@ -62,6 +62,7 @@ class GalleryItemGetListProcessor extends modObjectGetListProcessor {
                 WHERE Tags.item = galItem.id
             ) AS tags'
         ));
+        $c->groupBy('id');
         return $c;
     }
 


### PR DESCRIPTION
..._gallery_tags

For more detail, see this thread: http://forums.modx.com/thread/81497/gallery-component-only-showing-50-of-gallery-items-v1-5-2-on-modx-2-2-6-advanced
