### PR TITLE
Do not cache in getList() when $sort = RAND()

### DIFF
--- a/core/components/gallery/model/gallery/galalbum.class.php
+++ b/core/components/gallery/model/gallery/galalbum.class.php
@@ -326,12 +326,13 @@ class galAlbum extends xPDOSimpleObject {
             $c->sortby($sort,$dir);
             if ($limit > 0) { $c->limit($limit,$start); }
             $albums = $modx->getCollection('galAlbum',$c);
-
-            $cache = array();
-            foreach ($albums as $album) {
-                $cache[] = $album->toArray('',true);
-            }
-            $modx->cacheManager->set($cacheKey,$cache);
+			if($sort !== 'RAND()') {
+	            $cache = array();
+	            foreach ($albums as $album) {
+	                $cache[] = $album->toArray('',true);
+	            }
+	            $modx->cacheManager->set($cacheKey,$cache);
+			}
         }
         return $albums;
     }


### PR DESCRIPTION
If call [[!GalleryAlbums&sort=`rand`&limit=`4`]] it was sorted by RAND() only first time
