### PR TITLE
Update snippet.gallery.php

### DIFF
--- a/core/components/gallery/elements/snippets/snippet.gallery.php
+++ b/core/components/gallery/elements/snippets/snippet.gallery.php
@@ -98,6 +98,9 @@ $linkToImage = $modx->getOption('linkToImage',$scriptProperties,false);
 $activeCls = $modx->getOption('activeCls',$scriptProperties,'gal-item-active');
 $highlightItem = $modx->getOption($imageGetParam,$_REQUEST,false);
 /** @var galItem $item */
+
+if (!is_array($data)) return '';
+
 foreach ($data['items'] as $item) {
     $itemArray = $item->toArray();
     $itemArray['idx'] = $idx;


### PR DESCRIPTION
Empty galleries return an empty string. ($data)
PHP throws a fatal error "Cannot use string offset as an array".

Added a type check to break.
