### PR TITLE
Added media source support to plugin

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -90,6 +90,15 @@ $settings['gallery.thumbs_prepend_site_url']->fromArray(array(
     'area' => '',
 ),'',true,true);
 
+$settings['gallery.mediaSource']= $modx->newObject('modSystemSetting');
+$settings['gallery.mediaSource']->fromArray(array(
+    'key' => 'gallery.mediaSource',
+    'value' => 1,
+    'xtype' => 'modx-combo-source',
+    'namespace' => 'gallery',
+    'area' => '',
+),'',true,true);
+
 /*
 $settings['gallery.']= $modx->newObject('modSystemSetting');
 $settings['gallery.']->fromArray(array(

--- a/core/components/gallery/elements/snippets/snippet.gallery.php
+++ b/core/components/gallery/elements/snippets/snippet.gallery.php
@@ -106,7 +106,7 @@ foreach ($data['items'] as $item) {
         $itemArray['cls'] .= ' '.$activeCls;
     }
     $itemArray['filename'] = basename($item->get('filename'));
-    $itemArray['image_absolute'] = $filesUrl.$item->get('filename');
+    $itemArray['image_absolute'] = $item->get('base_url').$filesUrl.$item->get('filename');
     $itemArray['fileurl'] = $itemArray['image_absolute'];
     $itemArray['filepath'] = $filesPath.$item->get('filename');
     $itemArray['filesize'] = $item->get('filesize');

--- a/core/components/gallery/model/gallery/galalbum.class.php
+++ b/core/components/gallery/model/gallery/galalbum.class.php
@@ -213,9 +213,6 @@ class galAlbum extends xPDOSimpleObject {
         $relativePath = $albumDir.$shortName;
         $absolutePath = $targetDir.$shortName;
 
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] shortName: '.$shortName);
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] newName: '.$relativePath);
-
         $fileName = str_replace(' ','',$relativePath);
 
         $file = array("name" => $shortName, "tmp_name" => $filePath,"error" => "0"); // emulate a $_FILES object
@@ -228,11 +225,8 @@ class galAlbum extends xPDOSimpleObject {
             $bytes = stream_copy_to_stream($input, $target);
             fclose($input);
             fclose($target);
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Created (stream): '.$targetDir.$shortName);
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Created File: '.$this->getPath(true).$shortName);
         } else {
             $success = $mediaSource->uploadObjectsToContainer($targetDir,array($file));
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Created (upload): '.$fileName);
         }
 
         // if(!$success) {

--- a/core/components/gallery/model/gallery/galalbum.class.php
+++ b/core/components/gallery/model/gallery/galalbum.class.php
@@ -201,21 +201,10 @@ class galAlbum extends xPDOSimpleObject {
         $albumDir = $this->getPath(false);
         $targetDir = str_ireplace(MODX_BASE_PATH, '', $this->getPath());
 
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] albumDir: '.$albumDir);
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] targetDir: '.$targetDir);
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] filePath: '.$filePath);
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] relFilePath: '.$filePath);
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] name: '.$name);
-
         /* if directory doesnt exist, create it */
         if (!$mediaSource->createContainer($targetDir,'/')) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Could not create directory (possibly already exists?): '.$targetDir);
-            // return $fileName;
         }
-        // if (!$this->isPathWritable()) {
-        //     $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Could not write to directory: '.$targetDir);
-        //     return $fileName;
-        // }
 
         /* upload the file */
 
@@ -224,13 +213,6 @@ class galAlbum extends xPDOSimpleObject {
         $relativePath = $albumDir.$shortName;
         $absolutePath = $targetDir.$shortName;
 
-        // if (@file_exists($absolutePath)) {
-        //     @unlink($absolutePath);
-        // }
-        // if (!@move_uploaded_file($filePath,$absolutePath)) {
-        //     $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] An error occurred while trying to upload the file: '.$filePath.' to '.$absolutePath);
-        // } else {
-        // }
         $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] shortName: '.$shortName);
         $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] newName: '.$relativePath);
 
@@ -238,7 +220,7 @@ class galAlbum extends xPDOSimpleObject {
 
         $file = array("name" => $shortName, "tmp_name" => $filePath,"error" => "0"); // emulate a $_FILES object
 
-        $upErrors = false;
+        $success = true;
         // modFileMediaSource class uses move_uploaded_file - because we create a local file - we cannot use this function and we use streams instead
         if(!is_uploaded_file($filePath) && get_class($mediaSource) == 'modFileMediaSource_mysql') {
             $input = fopen($filePath, "r");
@@ -249,14 +231,14 @@ class galAlbum extends xPDOSimpleObject {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Created (stream): '.$targetDir.$shortName);
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Created File: '.$this->getPath(true).$shortName);
         } else {
-            $upErrors = $mediaSource->uploadObjectsToContainer($targetDir,array($file));
+            $success = $mediaSource->uploadObjectsToContainer($targetDir,array($file));
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Created (upload): '.$fileName);
         }
 
-        if($upErrors) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] An error occurred while trying to upload the file: '.$filePath.' to '.$absolutePath);
-            return false;
-        }
+        // if(!$success) {
+        //     $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] An error occurred while trying to upload the file: '.$filePath.' to '.$absolutePath);
+        //     return false;
+        // }
         return $fileName;
     }
 

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -117,6 +117,14 @@ class galItem extends xPDOSimpleObject {
             case 'image_path':
                 $value = $this->xpdo->call('galAlbum','getFilesPath',array(&$this->xpdo)).$this->get('filename');
                 break;
+            case 'base_url':
+                $ms = $this->getMediaSource();
+                $value='';
+                if($ms->getBaseUrl() != '/') {
+                    $value = $ms->getBaseUrl();
+                }
+
+                break;
             default:
                 $value = parent::get($k,$format,$formatTemplate);
                 break;

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -28,11 +28,12 @@ class galItem extends xPDOSimpleObject {
     private function getMediaSource() {
         if($this->mediaSource) return $this->mediaSource;
         //get modMediaSource
-        $media = new modMediaSource($this->xpdo); //$this->xpdo->loadClass('sources.modMediaSource');
         $mediaSource = $this->xpdo->getOption('gallery.mediaSource',null,1);
 
-        // find our one
-        $def = $media->getDefaultSource($this->xpdo, $mediaSource);
+        $def = $this->xpdo->getObject('sources.modMediaSource',array(
+            'id' => $mediaSource,
+        ));
+
         $def->initialize();
 
         $this->mediaSource = $def;

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -88,10 +88,10 @@ class galItem extends xPDOSimpleObject {
                 $siteUrl = $this->getSiteUrl();
                 $value = $siteUrl.$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$this->get('filename');
 
-                $ms = $this->getMediaSource();
-                if($ms->getBaseUrl() != '/') {
-                    $value = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
-                }
+                // $ms = $this->getMediaSource();
+                // if($ms->getBaseUrl() != '/') {
+                //     $value = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
+                // }
 
                 break;
             case 'relativeImage':
@@ -103,10 +103,10 @@ class galItem extends xPDOSimpleObject {
                     $value = str_replace($baseUrl,'',$path);
                 }
 
-                $ms = $this->getMediaSource(); // for absolute + relative the link NEEDS the http:// domain
-                if($ms->getBaseUrl() != '/') {
-                    $value = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
-                }
+                // $ms = $this->getMediaSource(); // for absolute + relative the link NEEDS the http:// domain
+                // if($ms->getBaseUrl() != '/') {
+                //     $value = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$baseUrl;
+                // }
 
                 break;
             case 'filesize':
@@ -209,7 +209,9 @@ class galItem extends xPDOSimpleObject {
         $filename = $this->get('filename');
         if (!empty($filename)) {
             $filename = $this->xpdo->call('galAlbum','getFilesPath',array(&$this->xpdo)).$filename;
-            if (!@unlink($filename)) {
+            $filename = str_ireplace(MODX_BASE_PATH, '', $filename);
+            $ms = $this->getMediaSource();
+            if (!@$ms->removeObject($filename)) {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] An error occurred while trying to remove the attachment file at: '.$filename);
             }
         }

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -23,6 +23,23 @@
  * @package gallery
  */
 class galItem extends xPDOSimpleObject {
+    private $mediaSource;
+
+    private function getMediaSource() {
+
+        //get modMediaSource
+        $media = new modMediaSource($this->xpdo); //$this->xpdo->loadClass('sources.modMediaSource');
+        $mediaSource = $this->xpdo->getOption('gallery.mediaSource',null,1);
+
+        // find our one
+        $def = $media->getDefaultSource($this->xpdo, $mediaSource);
+        $def->initialize();
+
+        $this->mediaSource = $def;
+
+
+    }
+
     public function get($k, $format = null, $formatTemplate= null) {
         switch ($k) {
             case 'thumbnail':
@@ -130,6 +147,7 @@ class galItem extends xPDOSimpleObject {
      * @return boolean
      */
     public function upload($file,$albumId) {
+        $this->getMediaSource();
         if (empty($file) || empty($file['tmp_name']) || empty($file['name'])) return false;
         if (in_array($this->get('id'),array(0,null,''))) return false;
         /** @var galAlbum $album */

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -52,6 +52,12 @@ class galItem extends xPDOSimpleObject {
                     $format['src'] = $this->getSiteUrl();
                     $format['src'] .= $this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
                 }
+
+                $ms = $this->getMediaSource();
+                if($ms->getBaseUrl() != '/') {
+                    $format['src'] = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
+                }
+
                 $url = $value.'&'.http_build_query($format,'','&');
                 if ($this->xpdo->getOption('xhtml_urls',null,false)) {
                     $value = str_replace('&','&amp;',$url);
@@ -69,12 +75,24 @@ class galItem extends xPDOSimpleObject {
                     $format['src'] = $this->getSiteUrl();
                     $format['src'] .= $this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
                 }
+
+                $ms = $this->getMediaSource();
+                if($ms->getBaseUrl() != '/') {
+                    $format['src'] = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
+                }
+
                 $value = $this->getPhpThumbUrl().'&'.http_build_query($format,'','&');
                 $value = $this->xpdo->getOption('xhtml_urls',null,false) ? str_replace('&','&amp;',$value) : $value;
                 break;
             case 'absoluteImage':
                 $siteUrl = $this->getSiteUrl();
                 $value = $siteUrl.$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$this->get('filename');
+
+                $ms = $this->getMediaSource();
+                if($ms->getBaseUrl() != '/') {
+                    $value = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
+                }
+
                 break;
             case 'relativeImage':
                 $baseUrl = $this->getOption('base_url');
@@ -84,6 +102,12 @@ class galItem extends xPDOSimpleObject {
                 } else {
                     $value = str_replace($baseUrl,'',$path);
                 }
+
+                $ms = $this->getMediaSource(); // for absolute + relative the link NEEDS the http:// domain
+                if($ms->getBaseUrl() != '/') {
+                    $value = $ms->getBaseUrl().$this->xpdo->call('galAlbum','getFilesUrl',array(&$this->xpdo)).$filename;
+                }
+
                 break;
             case 'filesize':
                 $filename = $this->xpdo->call('galAlbum','getFilesPath',array(&$this->xpdo)).$this->get('filename');

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -23,10 +23,10 @@
  * @package gallery
  */
 class galItem extends xPDOSimpleObject {
-    private $mediaSource;
+    private $mediaSource = false;
 
     private function getMediaSource() {
-
+        if($this->mediaSource) return $this->mediaSource;
         //get modMediaSource
         $media = new modMediaSource($this->xpdo); //$this->xpdo->loadClass('sources.modMediaSource');
         $mediaSource = $this->xpdo->getOption('gallery.mediaSource',null,1);
@@ -37,7 +37,7 @@ class galItem extends xPDOSimpleObject {
 
         $this->mediaSource = $def;
 
-
+        return $this->mediaSource;
     }
 
     public function get($k, $format = null, $formatTemplate= null) {
@@ -147,14 +147,13 @@ class galItem extends xPDOSimpleObject {
      * @return boolean
      */
     public function upload($file,$albumId) {
-        $this->getMediaSource();
         if (empty($file) || empty($file['tmp_name']) || empty($file['name'])) return false;
         if (in_array($this->get('id'),array(0,null,''))) return false;
         /** @var galAlbum $album */
         $album = $this->xpdo->getObject('galAlbum',$albumId);
         if (empty($album)) return false;
 
-        $fileName = $album->uploadItem($this,$file['tmp_name'],$file['name']);
+        $fileName = $album->uploadItem($this,$file['tmp_name'], $file['name'], $this->getMediaSource());
         if (empty($fileName)) {
             return false;
         }

--- a/core/components/gallery/model/gallery/import/galzipimport.class.php
+++ b/core/components/gallery/model/gallery/import/galzipimport.class.php
@@ -120,10 +120,10 @@ class galZipImport extends galImport {
         $newRelativePath = $this->albumId.'/'.$newFileName;
         $newAbsolutePath = $this->target.'/'.$newFileName;
 
-        if (@file_exists($newAbsolutePath)) {
-            @unlink($newAbsolutePath);
-        }
-        if (!@copy($filePathName,$newAbsolutePath)) {
+        $file = array("name" => $newRelativePath, "tmp_name" => $filePathName, "error" => "0"); // emulate a $_FILES object
+
+        $success = $item->upload($file,$options['album']);
+        if(!$success) {
             $errors[] = $this->modx->lexicon('gallery.file_err_move',array(
                 'file' => $newFileName,
                 'target' => $newAbsolutePath,

--- a/core/components/gallery/processors/mgr/item/ajaxupload.php
+++ b/core/components/gallery/processors/mgr/item/ajaxupload.php
@@ -69,9 +69,7 @@ if (!empty($_FILES['qqfile'])) {
 
     $file = array("name" => $relativePath, "tmp_name" => $randomFilename, "error" => "0"); // emulate a $_FILES object
 
-    $opts = $item->upload($file,$scriptProperties['album']);
     $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Album Type: '.$scriptProperties['album']);
-    $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Upload Type: '.$opts);
 
 
     if ($bytes == 0 || !$item->upload($file,$scriptProperties['album'])) {

--- a/core/components/gallery/processors/mgr/item/ajaxupload.php
+++ b/core/components/gallery/processors/mgr/item/ajaxupload.php
@@ -28,29 +28,26 @@ if (!$item->save()) {
 $albumDir = $album.'/';
 $targetDir = $modx->call('galAlbum','getFilesPath',array(&$modx)).$albumDir;
 
-$cacheManager = $modx->getCacheManager();
-/* if directory doesnt exist, create it */
-if (!file_exists($targetDir) || !is_dir($targetDir)) {
-    if (!$cacheManager->writeTree($targetDir)) {
-       $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Could not create directory: '.$targetDir);
-       return $modx->toJSON(array('error' => 'Could not create directory: ' . $targetDir));
-    }
-}
-/* make sure directory is readable/writable */
-if (!is_readable($targetDir) || !is_writable($targetDir)) {
-    $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Could not write to directory: '.$targetDir);
-    return $modx->toJSON(array('error' => 'Could not write to directory: ' . $targetDir));
-}
+// $cacheManager = $modx->getCacheManager();
+// /* if directory doesnt exist, create it */
+// if (!file_exists($targetDir) || !is_dir($targetDir)) {
+//     if (!$cacheManager->writeTree($targetDir)) {
+//        $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Could not create directory: '.$targetDir);
+//        return $modx->toJSON(array('error' => 'Could not create directory: ' . $targetDir));
+//     }
+// }
+// /* make sure directory is readable/writable */
+// if (!is_readable($targetDir) || !is_writable($targetDir)) {
+//     $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Could not write to directory: '.$targetDir);
+//     return $modx->toJSON(array('error' => 'Could not write to directory: ' . $targetDir));
+// }
 
 /* upload the file */
-$extension = end(explode('.', $filenm));
+$extension = @end(explode('.', $filenm));
 $filename = $item->get('id').'.'.$extension;
 $relativePath = $albumDir.$filename;
 $absolutePath = $targetDir.$filename;
 
-if (@file_exists($absolutePath)) {
-    @unlink($absolutePath);
-}
 
 if (!empty($_FILES['qqfile'])) {
     if (!$item->upload($_FILES['qqfile'],$scriptProperties['album'])) {
@@ -58,20 +55,34 @@ if (!empty($_FILES['qqfile'])) {
         return $modx->error->failure($modx->lexicon('gallery.item_err_upload'));
     }
 } else {
-    /* Using AJAX upload */
+    $modx->log(xPDO::LOG_LEVEL_ERROR,'[GalleryAjaxUpload] filenm '.$filenm);
+
+    $length = 10;
+    $randomFilename = "/tmp/".substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, $length).".$extension";
+
+    /* Using AJAX upload - to tmp file then use the correct media source to upload */
     $input = fopen("php://input", "r");
-    $target = fopen($absolutePath, "w");
+    $target = fopen($randomFilename, "w");
     $bytes = stream_copy_to_stream($input, $target);
     fclose($input);
     fclose($target);
-    
-    if ($bytes == 0) {
+
+    $file = array("name" => $relativePath, "tmp_name" => $randomFilename, "error" => "0"); // emulate a $_FILES object
+
+    $opts = $item->upload($file,$scriptProperties['album']);
+    $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Album Type: '.$scriptProperties['album']);
+    $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Upload Type: '.$opts);
+
+
+    if ($bytes == 0 || !$item->upload($file,$scriptProperties['album'])) {
         $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] An error occurred while trying to upload the file to '.$absolutePath);
         $item->remove();
         return $modx->toJSON(array('error' => 'gallery.item_err_upload'));
     } else {
         $item->set('filename',str_replace(' ','',$relativePath));
     }
+
+    @unlink($target);
 }
 
 $item->save();

--- a/core/components/gallery/processors/mgr/item/batchupload.php
+++ b/core/components/gallery/processors/mgr/item/batchupload.php
@@ -56,20 +56,6 @@ $fullpath = $modx->fileHandler->sanitizePath($directory);
 
 $targetDir = $modx->call('galAlbum','getFilesPath',array(&$modx)).$scriptProperties['album'].'/';
 
-$cacheManager = $modx->getCacheManager();
-/* if directory doesnt exist, create it */
-if (!file_exists($targetDir) || !is_dir($targetDir)) {
-    if (!$cacheManager->writeTree($targetDir)) {
-       $modx->log(modX::LOG_LEVEL_ERROR,'[Gallery] Could not create directory: '.$targetDir);
-       return $modx->error->failure($modx->lexicon('gallery.directory_err_create',array('directory' => $targetDir)));
-    }
-}
-/* make sure directory is readable/writable */
-if (!is_readable($targetDir) || !is_writable($targetDir)) {
-    $modx->log(xPDO::LOG_LEVEL_ERROR,'[Gallery] Could not write to directory: '.$targetDir);
-    return $modx->error->failure($modx->lexicon('gallery.directory_err_write',array('directory' => $targetDir)));
-}
-
 $imagesExts = array('jpg','jpeg','png','gif','bmp');
 $use_multibyte = $modx->getOption('use_multibyte',null,false);
 $encoding = $modx->getOption('modx_charset',null,'UTF-8');
@@ -101,11 +87,11 @@ foreach (new DirectoryIterator($fullpath) as $file) {
     $newFileName = $item->get('id').'.'.$fileExtension;
     $newRelativePath = $scriptProperties['album'].'/'.$newFileName;
     $newAbsolutePath = $targetDir.'/'.$newFileName;
-    
-    if (@file_exists($newAbsolutePath)) {
-        @unlink($newAbsolutePath);
-    }
-    if (!@copy($filePathName,$newAbsolutePath)) {
+
+    $file = array("name" => $newRelativePath, "tmp_name" => $filePathName, "error" => "0"); // emulate a $_FILES object
+
+    $success = $item->upload($file,$scriptProperties['album']);
+    if(!$success) {
         $errors[] = $modx->lexicon('gallery.file_err_move',array(
             'file' => $newFileName,
             'target' => $newAbsolutePath,


### PR DESCRIPTION
Plugin now supports a media source (defaults to filesystem).

A drop-in extra that allows the gallery to use a media source (for example S3, or cloud files). I have updated the uploaders and the file paths in the get() function to allow for urls at the start of filenames.

We are currently using this in production and have no issues.
