### PR TITLE
fixed situation then rank of source and target entities is the same

### DIFF
--- a/core/components/gallery/processors/mgr/item/sort.php
+++ b/core/components/gallery/processors/mgr/item/sort.php
@@ -48,7 +48,7 @@ if ($source->get('rank') < $target->get('rank')) {
         AND rank > 0
     ");
     $newRank = $target->get('rank');
-} else {
+} elseif($source->get('rank') > $target->get('rank')) {
     $modx->exec("
         UPDATE {$modx->getTableName('galAlbumItem')}
             SET rank = rank + 1


### PR DESCRIPTION
Then i sorting images in admin panel, i have a mismatch a short position on drag and drop action after save. It was happen because condition of check rank on saving was not correct.
